### PR TITLE
Support additional Raspberry Pi models, and USB WiFi adapters

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,13 @@
 connector-api:
-    cd src && rm -f connector-api && GOOS=linux GOARCH=arm64 go build -ldflags "-s -w" -o connector-api
+    #!/usr/bin/env bash
+    ALPINE_ARCH="${ALPINE_ARCH:-aarch64}"
+    if [ "$ALPINE_ARCH" = "armv7" ]; then
+        export GOARCH=arm
+        export GOARM=7
+    else
+        export GOARCH=arm64
+    fi
+    cd src && rm -f connector-api && GOOS=linux go build -ldflags "-s -w" -o connector-api
 
 run: connector-api
     sudo ./build.sh

--- a/Justfile
+++ b/Justfile
@@ -10,7 +10,7 @@ connector-api:
     cd src && rm -f connector-api && GOOS=linux go build -ldflags "-s -w" -o connector-api
 
 run: connector-api
-    sudo ./build.sh
+    sudo -E ./build.sh
 
 lint:
     pre-commit run --all-files

--- a/Justfile
+++ b/Justfile
@@ -4,6 +4,9 @@ connector-api:
     if [ "$ALPINE_ARCH" = "armv7" ]; then
         export GOARCH=arm
         export GOARM=7
+    elif [ "$ALPINE_ARCH" = "armhf" ]; then
+        export GOARCH=arm
+        export GOARM=6
     else
         export GOARCH=arm64
     fi

--- a/README.md
+++ b/README.md
@@ -26,10 +26,9 @@
 ## Prerequisites
 
 - Raspberry Pi with networking
-  - Pi 1 and Pi Zero 1 (W) is not supported due to the old architecture
-  - Pi 2 requires custom build instructions, see below
+  - Pi 1, Pi Zero 1 (W), and Pi 2 require custom build instructions, see below
 - SD card
-  - Nocturne Connector is super small (~60 MB for Pi 3+, ~150MB for Pi 2), so you have many choices for SD cards
+  - Nocturne Connector is super small (~60 MB for Pi 3+, ~150MB for Pi 1/2/Zero), so you have many choices for SD cards
 - Working Wi-Fi network
 - Car Thing with Nocturne 3.0.0 or later installed
 
@@ -68,11 +67,13 @@ Available recipes:
   run
 ```
 
-### Raspberry Pi 2 Support
+### Building for Pi 1, 2, and Zero
 
-The Pi 2 does not have onboard Wi-Fi, and uses an older ARMv7 32-bit architecture, so support is limited.
+The Pi 1, 2, and original Zero doe not have onboard Wi-Fi, and us older 32-bit ARM architectures, so support is limited.
 
 However, if you have a compatible Realtek/Mediatek WiFi adapter (e.g., the [CanoKit Wi-Fi USB adapter](https://www.canakit.com/raspberry-pi-wifi.html), included with some Raspberry Pi 2 kits), you can follow these build instructions to create a working image:
+
+**Raspberry Pi 2:**
 
 1. Start up the qemu-user-static Docker container on your build host (see above)
 2. Invoke build steps specified in the Justfile with environment variables `USB_WIFI_SUPPORT=true ALPINE_ARCH=armv7`:
@@ -80,6 +81,16 @@ However, if you have a compatible Realtek/Mediatek WiFi adapter (e.g., the [Cano
 ```
 $ USB_WIFI_SUPPORT=true ALPINE_ARCH=armv7 just run
 ```
+
+**Raspberry Pi 1 / Zero:**
+
+1. Start up the qemu-user-static Docker container on your build host (see above)
+2. Invoke build steps specified in the Justfile with environment variables `USB_WIFI_SUPPORT=true ALPINE_ARCH=armhf`:
+
+```
+$ USB_WIFI_SUPPORT=true ALPINE_ARCH=armhf just run
+```
+
 
 Then use Raspberry Pi Imager or another image flash tool to write the produced `img.gz` to a MicroSD card, and be sure to connect the USB Wi-Fi adapter.
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@
 ## Prerequisites
 
 - Raspberry Pi with networking
-  - Pi 1 and 2 are not supported due to the lack of onboard Wi-Fi
-  - Pi Zero 1 (W) is not supported due to the old architecture
+  - Pi 1 and Pi Zero 1 (W) is not supported due to the old architecture
+  - Pi 2 requires custom build instructions, see below
 - SD card
-  - Nocturne Connector is super small (~60 MB), so you have many choices for SD cards
+  - Nocturne Connector is super small (~60 MB for Pi 3+, ~150MB for Pi 2), so you have many choices for SD cards
 - Working Wi-Fi network
 - Car Thing with Nocturne 3.0.0 or later installed
 
@@ -67,6 +67,23 @@ Available recipes:
   lint
   run
 ```
+
+### Raspberry Pi 2 Support
+
+The Pi 2 does not have onboard Wi-Fi, and uses an older ARMv7 32-bit architecture, so support is limited.
+
+However, if you have a compatible Realtek/Mediatek WiFi adapter (e.g., the [CanoKit Wi-Fi USB adapter](https://www.canakit.com/raspberry-pi-wifi.html), included with some Raspberry Pi 2 kits), you can follow these build instructions to create a working image:
+
+1. Start up the qemu-user-static Docker container on your build host (see above)
+2. Invoke build steps specified in the Justfile with environment variables `USB_WIFI_SUPPORT=true ALPINE_ARCH=armv7`:
+
+```
+$ USB_WIFI_SUPPORT=true ALPINE_ARCH=armv7 just run
+```
+
+Then use Raspberry Pi Imager or another image flash tool to write the produced `img.gz` to a MicroSD card, and be sure to connect the USB Wi-Fi adapter.
+
+This method has been tested with Realtek RT2x00 USB adapters, your mileage may vary.
 
 ## Tinkering (Advanced)
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Available recipes:
 
 ### Building for Pi 1, 2, and Zero
 
-The Pi 1, 2, and original Zero doe not have onboard Wi-Fi, and us older 32-bit ARM architectures, so support is limited.
+The Pi 1, 2, and original Zero do not have onboard Wi-Fi, and use older 32-bit ARM architectures, so support is limited.
 
 However, if you have a compatible Realtek/Mediatek WiFi adapter (e.g., the [CanoKit Wi-Fi USB adapter](https://www.canakit.com/raspberry-pi-wifi.html), included with some Raspberry Pi 2 kits), you can follow these build instructions to create a working image:
 

--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ set -e
 : "${SHUTDOWN_SERVICES:="killprocs"}"
 
 : "${SIZE_BOOT:="100M"}"
-: "${SIZE_ROOT:="100M"}"
+: "${SIZE_ROOT:="300M"}"
 
 : "${STAGES:="00 10 20 30 40"}"
 

--- a/build.sh
+++ b/build.sh
@@ -16,6 +16,8 @@ set -e
 : "${DEFAULT_HOSTNAME:="nocturne-connector"}"
 : "${DEFAULT_ROOT_PASSWORD:="nocturne"}"
 
+: "${USB_WIFI_SUPPORT:="false"}"
+
 : "${SYSINIT_SERVICES:="devfs dmesg hwdrivers"}"
 : "${BOOT_SERVICES:="sysctl hostname bootmisc modules"}"
 : "${DEFAULT_SERVICES:=""}"

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,7 @@ set -e
 
 : "${ALPINE_BUILD:="3.21"}"
 : "${ALPINE_BUILD_PATCH:="3"}"
+: "${ALPINE_ARCH:="aarch64"}"
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # System config

--- a/scripts/stages/00/40-apk.sh
+++ b/scripts/stages/00/40-apk.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-curl -L https://dl-cdn.alpinelinux.org/alpine/v"$ALPINE_BUILD"/releases/aarch64/alpine-minirootfs-"$ALPINE_BUILD"."$ALPINE_BUILD_PATCH"-aarch64.tar.gz | tar -xz -C "$ROOTFS_PATH"
+curl -L https://dl-cdn.alpinelinux.org/alpine/v"$ALPINE_BUILD"/releases/"$ALPINE_ARCH"/alpine-minirootfs-"$ALPINE_BUILD"."$ALPINE_BUILD_PATCH"-"$ALPINE_ARCH".tar.gz | tar -xz -C "$ROOTFS_PATH"
 
 "$HELPERS_PATH"/chroot_exec.sh apk update
 "$HELPERS_PATH"/chroot_exec.sh apk upgrade --available

--- a/scripts/stages/00/50-kernel.sh
+++ b/scripts/stages/00/50-kernel.sh
@@ -19,17 +19,19 @@ rmdir "$ROOTFS_PATH"/tempapk
   rm -f boot/System.map-* boot/config-*
 
   rm -rf lib/modules/*/kernel/{arch,sound,security,kernel}
-  find lib/modules/*/kernel/crypto ! -name 'zstd.ko.xz' -exec rm -rf {} + 2> /dev/null
 
   if [ "$USB_WIFI_SUPPORT" = "true" ]; then
+    # Keep all crypto modules for WiFi
     # Keep lib/crc-ccitt.ko for rt2800usb WiFi driver
     find lib/modules/*/kernel/lib ! -name 'crc-ccitt.ko.xz' -type f -exec rm -f {} + 2> /dev/null
   else
+    find lib/modules/*/kernel/crypto ! -name 'zstd.ko.xz' -exec rm -rf {} + 2> /dev/null
     rm -rf lib/modules/*/kernel/lib
   fi
 
   if [ "$USB_WIFI_SUPPORT" = "true" ]; then
-    rm -rf lib/modules/*/kernel/drivers/{ata,auxdisplay,accessibility,base,bcma,block,bluetooth,cdrom,clk,connector,gpu,hid,iio,input,i2c,leds,md,mfd,mmc,mtd,mux,nvmem,pinctrl,pps,rtc,scsi,spi,ssb,staging,uio,vhost,video,w1}
+    # Keep bcma and ssb for Broadcom WiFi support
+    rm -rf lib/modules/*/kernel/drivers/{ata,auxdisplay,accessibility,base,block,bluetooth,cdrom,clk,connector,gpu,hid,iio,input,i2c,leds,md,mfd,mmc,mtd,mux,nvmem,pinctrl,pps,rtc,scsi,spi,staging,uio,vhost,video,w1}
   else
     rm -rf lib/modules/*/kernel/drivers/{ata,auxdisplay,accessibility,base,bcma,block,bluetooth,cdrom,clk,connector,gpu,hid,iio,input,i2c,leds,md,mfd,mmc,mtd,mux,net,nvmem,pinctrl,pps,rtc,scsi,spi,ssb,staging,uio,vhost,video,w1}
   fi

--- a/scripts/stages/00/50-kernel.sh
+++ b/scripts/stages/00/50-kernel.sh
@@ -20,7 +20,13 @@ rmdir "$ROOTFS_PATH"/tempapk
 
   rm -rf lib/modules/*/kernel/{arch,sound,security,lib,kernel}
   find lib/modules/*/kernel/crypto ! -name 'zstd.ko.xz' -exec rm -rf {} + 2> /dev/null
-  rm -rf lib/modules/*/kernel/drivers/{ata,auxdisplay,accessibility,base,bcma,block,bluetooth,cdrom,clk,connector,gpu,hid,iio,input,i2c,leds,md,mfd,mmc,mtd,mux,nvmem,pinctrl,pps,rtc,scsi,spi,ssb,staging,uio,vhost,video,w1}
+
+  if [ "$USB_WIFI_SUPPORT" = "true" ]; then
+    rm -rf lib/modules/*/kernel/drivers/{ata,auxdisplay,accessibility,base,bcma,block,bluetooth,cdrom,clk,connector,gpu,hid,iio,input,i2c,leds,md,mfd,mmc,mtd,mux,nvmem,pinctrl,pps,rtc,scsi,spi,ssb,staging,uio,vhost,video,w1}
+  else
+    rm -rf lib/modules/*/kernel/drivers/{ata,auxdisplay,accessibility,base,bcma,block,bluetooth,cdrom,clk,connector,gpu,hid,iio,input,i2c,leds,md,mfd,mmc,mtd,mux,net,nvmem,pinctrl,pps,rtc,scsi,spi,ssb,staging,uio,vhost,video,w1}
+  fi
+
   rm -rf lib/modules/*/kernel/drivers/media/{cec,common,dvb-core,dvb-frontends,i2c,mc,pci,radio,rc,spi,test-drivers,tuners,v4l2-core,platform}
   rm -rf lib/modules/*/kernel/net/{6lowpan,9p,802,8021q,appletalk,atm,ax25,batman-adv,bluetooth,can,ceph,core,ieee802154,key,l2tp,llc,mpls,mptcp,netrom,nfc,nsh,openvswitch,rose,sched,sctp,vmw_vsock,xfrm}
 )

--- a/scripts/stages/00/50-kernel.sh
+++ b/scripts/stages/00/50-kernel.sh
@@ -18,8 +18,15 @@ rmdir "$ROOTFS_PATH"/tempapk
   cd "$WORK_PATH"/kernel || exit 1
   rm -f boot/System.map-* boot/config-*
 
-  rm -rf lib/modules/*/kernel/{arch,sound,security,lib,kernel}
+  rm -rf lib/modules/*/kernel/{arch,sound,security,kernel}
   find lib/modules/*/kernel/crypto ! -name 'zstd.ko.xz' -exec rm -rf {} + 2> /dev/null
+
+  if [ "$USB_WIFI_SUPPORT" = "true" ]; then
+    # Keep lib/crc-ccitt.ko for rt2800usb WiFi driver
+    find lib/modules/*/kernel/lib ! -name 'crc-ccitt.ko.xz' -type f -exec rm -f {} + 2> /dev/null
+  else
+    rm -rf lib/modules/*/kernel/lib
+  fi
 
   if [ "$USB_WIFI_SUPPORT" = "true" ]; then
     rm -rf lib/modules/*/kernel/drivers/{ata,auxdisplay,accessibility,base,bcma,block,bluetooth,cdrom,clk,connector,gpu,hid,iio,input,i2c,leds,md,mfd,mmc,mtd,mux,nvmem,pinctrl,pps,rtc,scsi,spi,ssb,staging,uio,vhost,video,w1}

--- a/scripts/stages/00/50-kernel.sh
+++ b/scripts/stages/00/50-kernel.sh
@@ -28,5 +28,9 @@ rmdir "$ROOTFS_PATH"/tempapk
   fi
 
   rm -rf lib/modules/*/kernel/drivers/media/{cec,common,dvb-core,dvb-frontends,i2c,mc,pci,radio,rc,spi,test-drivers,tuners,v4l2-core,platform}
-  rm -rf lib/modules/*/kernel/net/{6lowpan,9p,802,8021q,appletalk,atm,ax25,batman-adv,bluetooth,can,ceph,core,ieee802154,key,l2tp,llc,mpls,mptcp,netrom,nfc,nsh,openvswitch,rose,sched,sctp,vmw_vsock,xfrm}
+  if [ "$USB_WIFI_SUPPORT" = "true" ]; then
+    rm -rf lib/modules/*/kernel/net/{6lowpan,9p,802,8021q,appletalk,atm,ax25,batman-adv,bluetooth,can,ceph,core,ieee802154,key,l2tp,llc,mpls,mptcp,netrom,nfc,nsh,openvswitch,rose,sched,sctp,vmw_vsock,xfrm}
+  else
+    rm -rf lib/modules/*/kernel/net/{6lowpan,9p,802,8021q,appletalk,atm,ax25,batman-adv,bluetooth,can,ceph,core,ieee802154,key,l2tp,llc,mpls,mptcp,netrom,nfc,nsh,openvswitch,rose,sched,sctp,vmw_vsock,wireless,xfrm}
+  fi
 )

--- a/scripts/stages/00/50-kernel.sh
+++ b/scripts/stages/00/50-kernel.sh
@@ -21,9 +21,9 @@ rmdir "$ROOTFS_PATH"/tempapk
   rm -rf lib/modules/*/kernel/{arch,sound,security,kernel}
 
   if [ "$USB_WIFI_SUPPORT" = "true" ]; then
-    # Keep all crypto modules for WiFi
+    # Keep all crypto modules for WiFi (kernel/crypto and kernel/lib/crypto)
     # Keep lib/crc-ccitt.ko for rt2800usb WiFi driver
-    find lib/modules/*/kernel/lib ! -name 'crc-ccitt.ko.xz' -type f -exec rm -f {} + 2> /dev/null
+    find lib/modules/*/kernel/lib -type f ! -name 'crc-ccitt.ko.xz' ! -path '*/lib/crypto/*' -exec rm -f {} + 2> /dev/null
   else
     find lib/modules/*/kernel/crypto ! -name 'zstd.ko.xz' -exec rm -rf {} + 2> /dev/null
     rm -rf lib/modules/*/kernel/lib

--- a/scripts/stages/10/20-network.sh
+++ b/scripts/stages/10/20-network.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-"$HELPERS_PATH"/chroot_exec.sh apk add wireless-tools wpa_supplicant wpa_supplicant-openrc nftables eudev udev-init-scripts networkmanager networkmanager-cli linux-firmware-brcm networkmanager-wifi
+"$HELPERS_PATH"/chroot_exec.sh apk add wireless-tools wpa_supplicant wpa_supplicant-openrc nftables eudev udev-init-scripts networkmanager networkmanager-cli linux-firmware-brcm linux-firmware-ralink networkmanager-wifi
 
 mkdir -p "$ROOTFS_PATH"/etc/wpa_supplicant
 cat > "$ROOTFS_PATH"/etc/wpa_supplicant/wpa_supplicant.conf << EOF

--- a/scripts/stages/10/20-network.sh
+++ b/scripts/stages/10/20-network.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ "$USB_WIFI_SUPPORT" = "true" ]; then
-  "$HELPERS_PATH"/chroot_exec.sh apk add wireless-tools wpa_supplicant wpa_supplicant-openrc nftables eudev udev-init-scripts networkmanager networkmanager-cli linux-firmware-brcm linux-firmware-ralink linux-firmware-ath9k_htc linux-firmware-rtlwifi networkmanager-wifi
+  "$HELPERS_PATH"/chroot_exec.sh apk add wireless-tools wpa_supplicant wpa_supplicant-openrc nftables eudev udev-init-scripts networkmanager networkmanager-cli linux-firmware-brcm linux-firmware-other linux-firmware-ath9k_htc linux-firmware-rtlwifi networkmanager-wifi
 else
   "$HELPERS_PATH"/chroot_exec.sh apk add wireless-tools wpa_supplicant wpa_supplicant-openrc nftables eudev udev-init-scripts networkmanager networkmanager-cli linux-firmware-brcm networkmanager-wifi
 fi

--- a/scripts/stages/10/20-network.sh
+++ b/scripts/stages/10/20-network.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 
-"$HELPERS_PATH"/chroot_exec.sh apk add wireless-tools wpa_supplicant wpa_supplicant-openrc nftables eudev udev-init-scripts networkmanager networkmanager-cli linux-firmware-brcm linux-firmware-ralink networkmanager-wifi
+if [ "$USB_WIFI_SUPPORT" = "true" ]; then
+  "$HELPERS_PATH"/chroot_exec.sh apk add wireless-tools wpa_supplicant wpa_supplicant-openrc nftables eudev udev-init-scripts networkmanager networkmanager-cli linux-firmware-brcm linux-firmware-ralink linux-firmware-ath9k_htc linux-firmware-rtlwifi networkmanager-wifi
+else
+  "$HELPERS_PATH"/chroot_exec.sh apk add wireless-tools wpa_supplicant wpa_supplicant-openrc nftables eudev udev-init-scripts networkmanager networkmanager-cli linux-firmware-brcm networkmanager-wifi
+fi
 
 mkdir -p "$ROOTFS_PATH"/etc/wpa_supplicant
 cat > "$ROOTFS_PATH"/etc/wpa_supplicant/wpa_supplicant.conf << EOF

--- a/scripts/stages/10/20-network.sh
+++ b/scripts/stages/10/20-network.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ "$USB_WIFI_SUPPORT" = "true" ]; then
-  "$HELPERS_PATH"/chroot_exec.sh apk add wireless-tools wpa_supplicant wpa_supplicant-openrc nftables eudev udev-init-scripts networkmanager networkmanager-cli linux-firmware-brcm linux-firmware-other linux-firmware-ath9k_htc linux-firmware-rtlwifi networkmanager-wifi
+  "$HELPERS_PATH"/chroot_exec.sh apk add wireless-tools wpa_supplicant wpa_supplicant-openrc nftables eudev udev-init-scripts networkmanager networkmanager-cli linux-firmware-brcm linux-firmware-mediatek linux-firmware-other linux-firmware-ath9k_htc linux-firmware-rtlwifi networkmanager-wifi
 else
   "$HELPERS_PATH"/chroot_exec.sh apk add wireless-tools wpa_supplicant wpa_supplicant-openrc nftables eudev udev-init-scripts networkmanager networkmanager-cli linux-firmware-brcm networkmanager-wifi
 fi

--- a/scripts/stages/40/10-partitions.sh
+++ b/scripts/stages/40/10-partitions.sh
@@ -2,7 +2,7 @@
 
 # boot
 cp "$RES_PATH"/config/cmdline.txt "$RES_PATH"/config/config.txt "$BOOTFS_PATH"/
-if [ "$ALPINE_ARCH" = "armv7" ]; then
+if [ "$ALPINE_ARCH" = "armv7" ] || [ "$ALPINE_ARCH" = "armhf" ]; then
   sed -i 's/arm_64bit=1//g' "$BOOTFS_PATH"/config.txt
 fi
 rsync -a "$WORK_PATH"/kernel/boot/ "$BOOTFS_PATH"/

--- a/scripts/stages/40/10-partitions.sh
+++ b/scripts/stages/40/10-partitions.sh
@@ -2,6 +2,9 @@
 
 # boot
 cp "$RES_PATH"/config/cmdline.txt "$RES_PATH"/config/config.txt "$BOOTFS_PATH"/
+if [ "$ALPINE_ARCH" = "armv7" ]; then
+  sed -i 's/arm_64bit=1//g' "$BOOTFS_PATH"/config.txt
+fi
 rsync -a "$WORK_PATH"/kernel/boot/ "$BOOTFS_PATH"/
 
 m4 -D xFS=vfat -D xIMAGE=boot.xFS -D xLABEL="BOOT" -D xSIZE="$SIZE_BOOT" \

--- a/scripts/stages/40/30-compress.sh
+++ b/scripts/stages/40/30-compress.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-IMG_NAME="nocturne-connector_${CONNECTOR_IMAGE_VERSION}"
+IMG_NAME="nocturne-connector_${CONNECTOR_IMAGE_VERSION}_${ALPINE_ARCH}"
 
 rm -f "$OUTPUT_PATH"/"$IMG_NAME".img.gz "$OUTPUT_PATH"/"$IMG_NAME".img.gz.sha256
 pigz -c "$IMAGE_PATH"/sdcard.img > "$OUTPUT_PATH"/"$IMG_NAME".img.gz

--- a/scripts/stages/40/40-output.sh
+++ b/scripts/stages/40/40-output.sh
@@ -7,7 +7,7 @@ color_echo "used on rootfs: $(du -sh "$ROOTFS_PATH" | sed "s/\s.*//")" -Yellow
 echo
 
 color_echo ">> Compressed Sizes"
-color_echo "size of image: $(du -sh "$OUTPUT_PATH"/nocturne-connector_"$CONNECTOR_IMAGE_VERSION".img.gz | sed "s/\s.*//")" -Yellow
+color_echo "size of image: $(du -sh "$OUTPUT_PATH"/nocturne-connector_"$CONNECTOR_IMAGE_VERSION"_"$ALPINE_ARCH".img.gz | sed "s/\s.*//")" -Yellow
 echo
 
 color_echo "$WORK_PATH" -Yellow


### PR DESCRIPTION
* Adds `ALPINE_ARCH` env var which allows using an armv7 image for Raspberry Pi 2 devices, AND armhf image for Raspberry Pi 1 / Zero devices.
* Adds `USB_WIFI_SUPPORT` env var which allows adding additional RT2800usb for common USB Wi-FI cards
* Bumps root filesystem size from 100MB to 300MB. Unless you truly have a 256mb microSD card, this shouldn't matter -- the compressed size stays small. The final tar.gz is about 150MB for Pi 2 with USB WiFi support, from the original 60MB -- more or less a rounding error for modern systems.



I tested this and am running Nocturne Connector successfully on a Raspberry Pi 2B and Pi Zero with a Canakit USB Wi-FI adapter using the RT2800USB chipset!